### PR TITLE
Add MetaTrader async data provider

### DIFF
--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/README.md
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/README.md
@@ -43,6 +43,11 @@ When using the Polygon provider, currency pairs may be written with or without
 a `/` (e.g. `EURUSD` or `EUR/USD`). The data loaders automatically normalize
 the symbol for Polygon's API. For the `yfinance` provider, append `=X` to
 currency pairs (e.g. `EURUSD=X`).
+For the `metatrader` provider, install the `MetaTrader5` Python package and make
+sure the MetaTrader 5 terminal is installed on your computer. Launch the terminal,
+log in to your trading account and keep it running ("Algo Trading" enabled). The
+loader will connect to this local terminal to pull historical prices – no API key
+is required.
 
 
 ## 🔁 Feature Engineering

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
@@ -3,6 +3,7 @@ import aiohttp
 import pandas as pd
 import yfinance as yf
 from datetime import datetime
+import MetaTrader5 as mt5
 
 from .data_loader import normalize_symbol
 
@@ -54,6 +55,27 @@ async def fetch_yfinance(symbol, interval="1m", period="1y"):
     df.rename(columns={"Datetime": "timestamp", "Date": "timestamp", "Open": "open", "High": "high", "Low": "low", "Close": "close", "Adj Close": "close", "Volume": "volume"}, inplace=True)
     return df[["timestamp", "open", "high", "low", "close", "volume"]]
 
+async def fetch_metatrader_data(symbol, timeframe=mt5.TIMEFRAME_M1, start=None, end=None):
+    """Fetch OHLC data from a running MetaTrader 5 terminal."""
+    loop = asyncio.get_event_loop()
+
+    def _load():
+        if not mt5.initialize():
+            raise RuntimeError("MetaTrader5 initialization failed")
+        try:
+            records = mt5.copy_rates_range(symbol, timeframe, start, end)
+            return records
+        finally:
+            mt5.shutdown()
+
+    records = await loop.run_in_executor(None, _load)
+    if records is None:
+        return pd.DataFrame()
+    df = pd.DataFrame(records)
+    df["timestamp"] = pd.to_datetime(df["time"], unit="s")
+    df.rename(columns={"tick_volume": "volume"}, inplace=True)
+    return df[["timestamp", "open", "high", "low", "close", "volume"]]
+
 async def fetch_all_data(symbols, provider, api_key, **kwargs):
     async with aiohttp.ClientSession() as session:
         tasks = []
@@ -64,5 +86,7 @@ async def fetch_all_data(symbols, provider, api_key, **kwargs):
                 tasks.append(fetch_polygon_data(session, symbol, api_key, **kwargs))
             elif provider == "yfinance":
                 tasks.append(fetch_yfinance(symbol, **kwargs))
+            elif provider == "metatrader":
+                tasks.append(fetch_metatrader_data(symbol, **kwargs))
         results = await asyncio.gather(*tasks)
         return dict(zip(symbols, results))

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/environment.yml
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - tensorflow
   - pip
   - pip:
-      - ta
+      - MetaTrader5
       - shap
+      - ta
       - yfinance

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/requirements.txt
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/requirements.txt
@@ -1,9 +1,10 @@
-streamlit
-pandas
+MetaTrader5
 matplotlib
 numpy
 onnxruntime
-tsfresh
-shap
+pandas
 scikit-learn
+shap
+streamlit
+tsfresh
 yfinance


### PR DESCRIPTION
## Summary
- add `fetch_metatrader_data` coroutine for MT5 integration
- route `fetch_all_data` to new provider
- include `MetaTrader5` dependency
- document MetaTrader provider setup
- standardize volume column and tidy dependency files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476500ed94833289b54547591f6b7f