### PR TITLE
Fix import in async_data_loader

### DIFF
--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
@@ -5,7 +5,9 @@ import yfinance as yf
 from datetime import datetime
 import MetaTrader5 as mt5
 
-from .data_loader import normalize_symbol
+# Relative imports can cause issues when running this module as a script.
+# Import normalize_symbol from data_loader using an absolute import instead.
+from data_loader import normalize_symbol
 
 def parse_date(ts, fmt="%Y-%m-%d %H:%M:%S"):
     return datetime.strptime(ts, fmt)


### PR DESCRIPTION
## Summary
- use absolute import for `normalize_symbol` in `async_data_loader`

## Testing
- `python download_data.py --symbol EURUSD --provider yfinance` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6847742e7bd48332a47f1953b07b9343