### PR TITLE
Fix yfinance loader kwargs

### DIFF
--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
@@ -47,10 +47,18 @@ async def fetch_polygon_data(session, symbol, api_key, interval="minute", limit=
         for d in results
     ])
 
-async def fetch_yfinance(symbol, interval="1m", period="1y"):
+async def fetch_yfinance(symbol, interval="1m", period="1y", **_):
     """Fetch data from Yahoo Finance using a thread executor."""
     loop = asyncio.get_event_loop()
-    df = await loop.run_in_executor(None, lambda: yf.download(symbol, interval=interval, period=period, progress=False))
+    df = await loop.run_in_executor(
+        None,
+        lambda: yf.download(
+            symbol,
+            interval=interval,
+            period=period,
+            progress=False,
+        ),
+    )
     if df.empty:
         return pd.DataFrame()
     df = df.reset_index()

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/data_loader.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/data_loader.py
@@ -74,9 +74,14 @@ def load_tiingo(symbol, api_key, limit=500):
     } for d in data])
 
 
-def load_yfinance(symbol, interval="1m", period="1y"):
+def load_yfinance(symbol, interval="1m", period="1y", **_):
     """Load data from Yahoo Finance."""
-    df = yf.download(symbol, interval=interval, period=period, progress=False)
+    df = yf.download(
+        symbol,
+        interval=interval,
+        period=period,
+        progress=False,
+    )
     if df.empty:
         return pd.DataFrame()
     df = df.reset_index()


### PR DESCRIPTION
## Summary
- support unused kwargs in `fetch_yfinance` and `load_yfinance`

## Testing
- `python -m py_compile top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/data_loader.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68477752944c8332babb0f021f597ddc