### PR TITLE
Fix duplicate fetch_yfinance definition

### DIFF
--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
@@ -55,7 +55,6 @@ async def fetch_polygon_data(session, symbol, api_key, interval="minute", limit=
     ])
 
 async def fetch_yfinance(symbol, interval="1m", period="1y", **_):
-async def fetch_yfinance(symbol, interval="1m", period="1y", **_):
     """Fetch data from Yahoo Finance using a thread executor."""
     loop = asyncio.get_event_loop()
     df = await loop.run_in_executor(


### PR DESCRIPTION
## Summary
- remove an accidental duplicate of `fetch_yfinance`

## Testing
- `python -m py_compile top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68478399b50c8332ba63eae90d76e2fd