### PR TITLE
Add configurable Polygon date range

### DIFF
--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/README.md
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/README.md
@@ -38,6 +38,8 @@ use_correlation_filter: true
 label_horizon: 10
 label_method: binary
 ```
+`config.yaml` also allows setting `start` and `end` dates (YYYY-MM-DD) for data
+downloads when using providers like Polygon.
 
 When using the Polygon provider, currency pairs may be written with or without
 a `/` (e.g. `EURUSD` or `EUR/USD`). The data loaders automatically normalize
@@ -52,7 +54,8 @@ is required.
 Use `download_data.py` to fetch and cache data manually:
 This stores Parquet/HDF5 files under `data/` and prints quality stats.
 ```bash
-python download_data.py --symbol EURUSD --provider yfinance --api_key <key>
+python download_data.py --symbol EURUSD --provider yfinance --api_key <key> \
+  --start 2023-01-01 --end 2023-12-31
 ```
 Add `--compare-provider polygon` to fetch from a second source and see quality metrics.
 

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/async_data_loader.py
@@ -33,11 +33,20 @@ async def fetch_twelve_data(session, symbol, api_key, interval="1min", outputsiz
         "low": float(d["low"]), "close": float(d["close"]), "volume": float(d.get("volume", 0))
     } for d in reversed(values)])
 
-async def fetch_polygon_data(session, symbol, api_key, interval="minute", limit=500):
+async def fetch_polygon_data(
+    session,
+    symbol,
+    api_key,
+    interval="minute",
+    limit=500,
+    start="2023-01-01",
+    end="2023-12-31",
+):
+    """Fetch OHLC data from Polygon.io within a date range."""
     symbol_clean = normalize_symbol(symbol)
     url = (
         "https://api.polygon.io/v2/aggs/ticker/C:"
-        f"{symbol_clean}/range/1/{interval}/2023-01-01/2023-12-31"
+        f"{symbol_clean}/range/1/{interval}/{start}/{end}"
         f"?adjusted=true&sort=asc&limit={limit}&apiKey={api_key}"
     )
     data = await fetch_json(session, url)
@@ -54,7 +63,6 @@ async def fetch_polygon_data(session, symbol, api_key, interval="minute", limit=
         for d in results
     ])
 
-async def fetch_yfinance(symbol, interval="1m", period="1y", **_):
 async def fetch_yfinance(symbol, interval="1m", period="1y", **_):
     """Fetch data from Yahoo Finance using a thread executor."""
     loop = asyncio.get_event_loop()
@@ -113,12 +121,13 @@ async def fetch_all_data(symbols, provider, api_key, **kwargs):
 # Synchronous helpers copied from the old `data_loader` module
 # ---------------------------------------------------------------------------
 
-def load_polygon_data(symbol, api_key, interval="minute", limit=500):
+def load_polygon_data(symbol, api_key, interval="minute", limit=500, start="2023-01-01", end="2023-12-31"):
+    """Synchronously fetch Polygon.io data for a date range."""
     api_key = _resolve_key(api_key, "POLYGON_API_KEY")
     symbol_clean = normalize_symbol(symbol)
     url = (
         "https://api.polygon.io/v2/aggs/ticker/C:"
-        f"{symbol_clean}/range/1/{interval}/2023-01-01/2023-12-31"
+        f"{symbol_clean}/range/1/{interval}/{start}/{end}"
         f"?adjusted=true&sort=asc&limit={limit}&apiKey={api_key}"
     )
     resp = requests.get(url)

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/backtest.py
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/backtest.py
@@ -15,10 +15,22 @@ def run_backtest(config):
     api_key = config['api_keys'].get(provider, "")
     interval = config.get("interval", "1min")
     outputsize = config.get("outputsize", 500)
+    start = config.get("start", "2023-01-01")
+    end = config.get("end", "2023-12-31")
 
     if config.get("use_async", False):
         print(f"⚡ Async loading for {symbol}...")
-        df_dict = asyncio.run(fetch_all_data([symbol], provider, api_key, interval=interval, outputsize=outputsize))
+        df_dict = asyncio.run(
+            fetch_all_data(
+                [symbol],
+                provider,
+                api_key,
+                interval=interval,
+                outputsize=outputsize,
+                start=start,
+                end=end,
+            )
+        )
         df = df_dict[symbol]
     else:
         print(f"⏳ Sync loading for {symbol}...")
@@ -35,6 +47,8 @@ def run_backtest(config):
             api_key=api_key,
             interval=interval,
             outputsize=outputsize,
+            start=start,
+            end=end,
         )
 
     print(f"✅ Loaded {len(df)} rows for {symbol} — simulate training or backtest here")

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/batch_config.yaml
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/batch_config.yaml
@@ -3,6 +3,8 @@
   provider: "twelvedata"
   interval: "1min"
   outputsize: 100
+  start: "2023-01-01"
+  end: "2023-12-31"
   api_keys:
     twelvedata: "your_twelvedata_api_key"
     polygon: "your_polygon_api_key"
@@ -12,6 +14,8 @@
   provider: "polygon"
   interval: "minute"
   outputsize: 200
+  start: "2023-01-01"
+  end: "2023-12-31"
   api_keys:
     twelvedata: "your_twelvedata_api_key"
     polygon: "your_polygon_api_key"

--- a/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/config.yaml
+++ b/top5/RCS_CNN_LSTM_Notebook/RCS_CNN_LSTM_Notebook/config.yaml
@@ -3,6 +3,8 @@ symbol: "EUR/USD"
 provider: "twelvedata"
 interval: "1min"
 outputsize: 500
+start: "2023-01-01"
+end: "2023-12-31"
 
 api_keys:
   twelvedata: "your_twelvedata_api_key"


### PR DESCRIPTION
## Summary
- make Polygon data loaders accept `start` and `end` date parameters
- expose the new parameters in `backtest.py`
- document date range options in `config.yaml`, `batch_config.yaml` and README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847847a1b2c83328865751b706bad8d